### PR TITLE
Add the network-observe and network-setup-observe plugs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,6 +48,8 @@ apps:
     plugs:
       - avahi-control
       - network-bind
+      - network-observe
+      - network-setup-observe
       - log-observe
       - ppp
       - serial-port


### PR DESCRIPTION
Some homebridge plugins require access to network status, e.g. homebridge-network-presence.